### PR TITLE
refactor: remove `disableCSSOMInjection` support

### DIFF
--- a/benchmarks/vite.config.ts
+++ b/benchmarks/vite.config.ts
@@ -15,10 +15,7 @@ export default defineConfig({
     sourcemap: true,
     // minify: false,
   },
-  define: {
-    __VERSION__: JSON.stringify('benchmark'),
-    'process.env.SC_DISABLE_SPEEDY': JSON.stringify('false'),
-  },
+  define: { __VERSION__: JSON.stringify('benchmark') },
   resolve: {
     alias: {
       'react-native': 'react-native-web',

--- a/packages/css-in-js/package.json
+++ b/packages/css-in-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/css-in-js",
-  "version": "6.1.18-25",
+  "version": "6.1.18-26",
   "description": "A fork of styled-components that supports React 19 streaming ssr without ServerStyleSheet or sheet.collectStyles techniques",
   "publishConfig": {
     "access": "public"

--- a/packages/css-in-js/src/constants.ts
+++ b/packages/css-in-js/src/constants.ts
@@ -11,7 +11,5 @@ export const SPLITTER = '/*!sc*/\n';
 
 export const IS_BROWSER = typeof window !== 'undefined' && typeof document !== 'undefined';
 
-export const DISABLE_SPEEDY = false;
-
 // Shared empty execution context when generating static styles
 export const STATIC_EXECUTION_CONTEXT = {};

--- a/packages/css-in-js/src/models/StyleSheetManager.tsx
+++ b/packages/css-in-js/src/models/StyleSheetManager.tsx
@@ -34,12 +34,6 @@ export function useStyleSheetContext() {
 
 export type IStyleSheetManager = React.PropsWithChildren<{
   /**
-   * If desired, you can pass this prop to disable "speedy" insertion mode, which
-   * uses the browser [CSSOM APIs](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet).
-   * When disabled, rules are inserted as simple text into style blocks.
-   */
-  disableCSSOMInjection?: undefined | boolean;
-  /**
    * If you are working exclusively with modern browsers, vendor prefixes can often be omitted
    * to reduce the weight of CSS on the page.
    */
@@ -91,12 +85,8 @@ export function StyleSheetManager(props: IStyleSheetManager): React.JSX.Element 
       sheet = sheet.reconstructWithOptions({ target: props.target }, false);
     }
 
-    if (props.disableCSSOMInjection) {
-      sheet = sheet.reconstructWithOptions({ useCSSOMInjection: false });
-    }
-
     return sheet;
-  }, [props.disableCSSOMInjection, props.target, styleSheet]);
+  }, [props.target, styleSheet]);
 
   const stylis = useMemo(
     () =>

--- a/packages/css-in-js/src/models/test/StyleSheetManager.test.tsx
+++ b/packages/css-in-js/src/models/test/StyleSheetManager.test.tsx
@@ -460,43 +460,6 @@ describe('StyleSheetManager', () => {
     `);
   });
 
-  it('nested StyleSheetManager with different injection modes works', () => {
-    const Test = styled.div`
-      padding-left: 5px;
-    `;
-
-    const Test2 = styled.div`
-      background: red;
-    `;
-
-    const outerSheet = new StyleSheet({ useCSSOMInjection: true });
-
-    render(
-      <StyleSheetManager sheet={outerSheet}>
-        <div>
-          <Test>Foo</Test>
-          <StyleSheetManager disableCSSOMInjection>
-            <Test2>Bar</Test2>
-          </StyleSheetManager>
-        </div>
-      </StyleSheetManager>
-    );
-
-    expect(outerSheet.getTag().tag.getRule(0)).toMatchInlineSnapshot(`""`);
-
-    expect(document.head.innerHTML).toMatchInlineSnapshot(
-      `"<style data-styled="active" data-styled-version="JEST_MOCK_VERSION"></style><style data-styled="active" data-styled-version="JEST_MOCK_VERSION">.d{background:red;}</style><style data-styled="active" data-styled-version="JEST_MOCK_VERSION"></style>"`
-    );
-    expect(getRenderedCSS()).toMatchInlineSnapshot(`
-      ".c {
-        padding-left: 5px;
-      }
-      .d {
-        background: red;
-      }"
-    `);
-  });
-
   it('passing a namespace to StyleSheetManager works', () => {
     const Test = styled.div`
       display: flex;

--- a/packages/css-in-js/src/sheet/Sheet.ts
+++ b/packages/css-in-js/src/sheet/Sheet.ts
@@ -1,4 +1,4 @@
-import { DISABLE_SPEEDY, IS_BROWSER } from '../constants';
+import { IS_BROWSER } from '../constants';
 import { InsertionTarget } from '../types';
 import { EMPTY_OBJECT } from '../utils/empties';
 import { makeGroupedTag } from './GroupedTag';
@@ -8,7 +8,6 @@ import { GroupedTag, Sheet, SheetOptions } from './types';
 
 type SheetConstructorArgs = {
   isServer?: boolean;
-  useCSSOMInjection?: boolean;
   target?: InsertionTarget | undefined;
 };
 
@@ -19,7 +18,6 @@ type NamesAllocationMap = Map<string, Set<string>>;
 
 const defaultOptions: SheetOptions = {
   isServer: !IS_BROWSER,
-  useCSSOMInjection: !DISABLE_SPEEDY,
 };
 
 /** Contains the main stylesheet logic for stringification and caching */

--- a/packages/css-in-js/src/sheet/Tag.ts
+++ b/packages/css-in-js/src/sheet/Tag.ts
@@ -3,13 +3,11 @@ import { getSheet, makeStyleTag } from './dom';
 import { SheetOptions, Tag } from './types';
 
 /** Create a CSSStyleSheet-like tag depending on the environment */
-export const makeTag = ({ isServer, useCSSOMInjection, target }: SheetOptions) => {
+export const makeTag = ({ isServer, target }: SheetOptions) => {
   if (isServer) {
     return new VirtualTag(target);
-  } else if (useCSSOMInjection) {
-    return new CSSOMTag(target);
   } else {
-    return new TextTag(target);
+    return new CSSOMTag(target);
   }
 };
 
@@ -47,51 +45,8 @@ export class CSSOMTag implements Tag {
 
   getRule(index: number): string {
     const rule = this.sheet.cssRules[index];
-
     // Avoid IE11 quirk where cssText is inaccessible on some invalid rules
-    if (rule && rule.cssText) {
-      return rule.cssText;
-    } else {
-      return '';
-    }
-  }
-}
-
-/** A Tag that emulates the CSSStyleSheet API but uses text nodes */
-export class TextTag implements Tag {
-  element: HTMLStyleElement;
-  nodes: NodeListOf<Node>;
-  length: number;
-
-  constructor(target?: InsertionTarget | undefined) {
-    this.element = makeStyleTag(target);
-    this.nodes = this.element.childNodes;
-    this.length = 0;
-  }
-
-  insertRule(index: number, rule: string) {
-    if (index <= this.length && index >= 0) {
-      const node = document.createTextNode(rule);
-      const refNode = this.nodes[index];
-      this.element.insertBefore(node, refNode || null);
-      this.length++;
-      return true;
-    } else {
-      return false;
-    }
-  }
-
-  deleteRule(index: number) {
-    this.element.removeChild(this.nodes[index]);
-    this.length--;
-  }
-
-  getRule(index: number) {
-    if (index < this.length) {
-      return this.nodes[index].textContent as string;
-    } else {
-      return '';
-    }
+    return rule?.cssText ?? '';
   }
 }
 

--- a/packages/css-in-js/src/sheet/test/Tag.test.ts
+++ b/packages/css-in-js/src/sheet/test/Tag.test.ts
@@ -1,5 +1,5 @@
 import { C } from 'ts-toolbelt';
-import { CSSOMTag, TextTag, VirtualTag } from '../Tag';
+import { CSSOMTag, VirtualTag } from '../Tag';
 import { Tag } from '../types';
 
 const describeTag = (TagClass: C.Class<[], Tag>) => {
@@ -35,10 +35,6 @@ describe('CSSOMTag', () => {
     expect(childNodes.length).toBe(1);
     expect(childNodes[0].nodeName).toBe('#text');
   });
-});
-
-describe('TextTag', () => {
-  describeTag(TextTag);
 });
 
 describe('VirtualTag', () => {

--- a/packages/css-in-js/src/sheet/types.ts
+++ b/packages/css-in-js/src/sheet/types.ts
@@ -21,7 +21,6 @@ export interface GroupedTag {
 export type SheetOptions = {
   isServer: boolean;
   target?: InsertionTarget | undefined;
-  useCSSOMInjection: boolean;
 };
 
 export interface Sheet {

--- a/packages/styled-components/package.json
+++ b/packages/styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/styled-components",
-  "version": "6.1.18-11",
+  "version": "6.1.18-12",
   "description": "A fork of styled-components that supports concurrent rendering",
   "publishConfig": {
     "access": "public"

--- a/packages/styled-components/src/constants.ts
+++ b/packages/styled-components/src/constants.ts
@@ -13,7 +13,5 @@ export const SPLITTER = '/*!sc*/\n';
 
 export const IS_BROWSER = typeof window !== 'undefined' && typeof document !== 'undefined';
 
-export const DISABLE_SPEEDY = false;
-
 // Shared empty execution context when generating static styles
 export const STATIC_EXECUTION_CONTEXT = {};

--- a/packages/styled-components/src/constructors/test/createGlobalStyle.test.tsx
+++ b/packages/styled-components/src/constructors/test/createGlobalStyle.test.tsx
@@ -1,6 +1,5 @@
 import { render, fireEvent, screen, act } from '@testing-library/react';
 
-import { DISABLE_SPEEDY } from '../../constants';
 import { StyleSheetManager } from '../../models/StyleSheetManager';
 import ThemeProvider from '../../models/ThemeProvider';
 import StyleSheet from '../../sheet';
@@ -426,9 +425,6 @@ describe(`createGlobalStyle`, () => {
   });
 
   it(`removes style tag in StyleSheetManager.target when unmounted after target detached and no other global styles`, () => {
-    // This test requires speedy to be enabled
-    expect(DISABLE_SPEEDY).toBe(false);
-
     const container = document.createElement('div');
     document.body.appendChild(container);
 

--- a/packages/styled-components/src/models/StyleSheetManager.tsx
+++ b/packages/styled-components/src/models/StyleSheetManager.tsx
@@ -32,12 +32,6 @@ export function useStyleSheetContext() {
 
 export type IStyleSheetManager = React.PropsWithChildren<{
   /**
-   * If desired, you can pass this prop to disable "speedy" insertion mode, which
-   * uses the browser [CSSOM APIs](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet).
-   * When disabled, rules are inserted as simple text into style blocks.
-   */
-  disableCSSOMInjection?: undefined | boolean;
-  /**
    * If you are working exclusively with modern browsers, vendor prefixes can often be omitted
    * to reduce the weight of CSS on the page.
    */
@@ -91,12 +85,8 @@ export function StyleSheetManager(props: IStyleSheetManager): React.JSX.Element 
       sheet = sheet.reconstructWithOptions({ target: props.target }, false);
     }
 
-    if (props.disableCSSOMInjection) {
-      sheet = sheet.reconstructWithOptions({ useCSSOMInjection: false });
-    }
-
     return sheet;
-  }, [props.disableCSSOMInjection, props.sheet, props.target, styleSheet]);
+  }, [props.sheet, props.target, styleSheet]);
 
   const stylis = useMemo(
     () =>

--- a/packages/styled-components/src/models/test/StyleSheetManager.test.tsx
+++ b/packages/styled-components/src/models/test/StyleSheetManager.test.tsx
@@ -510,43 +510,6 @@ describe('StyleSheetManager', () => {
     `);
   });
 
-  it('nested StyleSheetManager with different injection modes works', () => {
-    const Test = styled.div`
-      padding-left: 5px;
-    `;
-
-    const Test2 = styled.div`
-      background: red;
-    `;
-
-    const outerSheet = new StyleSheet({ useCSSOMInjection: true });
-
-    render(
-      <StyleSheetManager sheet={outerSheet}>
-        <div>
-          <Test>Foo</Test>
-          <StyleSheetManager disableCSSOMInjection>
-            <Test2>Bar</Test2>
-          </StyleSheetManager>
-        </div>
-      </StyleSheetManager>
-    );
-
-    expect(outerSheet.getTag().tag.getRule(0)).toMatchInlineSnapshot(`".c {padding-left: 5px;}"`);
-
-    expect(document.head.innerHTML).toMatchInlineSnapshot(
-      `"<style data-styled="active" data-styled-version="JEST_MOCK_VERSION"></style><style data-styled="active" data-styled-version="JEST_MOCK_VERSION">.d{background:red;}</style>"`
-    );
-    expect(getRenderedCSS()).toMatchInlineSnapshot(`
-      ".c {
-        padding-left: 5px;
-      }
-      .d {
-        background: red;
-      }"
-    `);
-  });
-
   it('passing a namespace to StyleSheetManager works', () => {
     const Test = styled.div`
       display: flex;

--- a/packages/styled-components/src/sheet/Sheet.ts
+++ b/packages/styled-components/src/sheet/Sheet.ts
@@ -1,4 +1,4 @@
-import { DISABLE_SPEEDY, IS_BROWSER } from '../constants';
+import { IS_BROWSER } from '../constants';
 import { InsertionTarget } from '../types';
 import { EMPTY_OBJECT } from '../utils/empties';
 import { makeGroupedTag } from './GroupedTag';
@@ -11,7 +11,6 @@ let SHOULD_REHYDRATE = IS_BROWSER;
 
 type SheetConstructorArgs = {
   isServer?: boolean;
-  useCSSOMInjection?: boolean;
   target?: InsertionTarget | undefined;
 };
 
@@ -22,7 +21,6 @@ type NamesAllocationMap = Map<string, Set<string>>;
 
 const defaultOptions: SheetOptions = {
   isServer: !IS_BROWSER,
-  useCSSOMInjection: !DISABLE_SPEEDY,
 };
 
 /** Contains the main stylesheet logic for stringification and caching */

--- a/packages/styled-components/src/sheet/Tag.ts
+++ b/packages/styled-components/src/sheet/Tag.ts
@@ -3,13 +3,11 @@ import { getSheet, makeStyleTag } from './dom';
 import { SheetOptions, Tag } from './types';
 
 /** Create a CSSStyleSheet-like tag depending on the environment */
-export const makeTag = ({ isServer, useCSSOMInjection, target }: SheetOptions) => {
+export const makeTag = ({ isServer, target }: SheetOptions) => {
   if (isServer) {
     return new VirtualTag(target);
-  } else if (useCSSOMInjection) {
-    return new CSSOMTag(target);
   } else {
-    return new TextTag(target);
+    return new CSSOMTag(target);
   }
 };
 
@@ -51,44 +49,6 @@ export class CSSOMTag implements Tag {
     // Avoid IE11 quirk where cssText is inaccessible on some invalid rules
     if (rule && rule.cssText) {
       return rule.cssText;
-    } else {
-      return '';
-    }
-  }
-}
-
-/** A Tag that emulates the CSSStyleSheet API but uses text nodes */
-export class TextTag implements Tag {
-  element: HTMLStyleElement;
-  nodes: NodeListOf<Node>;
-  length: number;
-
-  constructor(target?: InsertionTarget | undefined) {
-    this.element = makeStyleTag(target);
-    this.nodes = this.element.childNodes;
-    this.length = 0;
-  }
-
-  insertRule(index: number, rule: string) {
-    if (index <= this.length && index >= 0) {
-      const node = document.createTextNode(rule);
-      const refNode = this.nodes[index];
-      this.element.insertBefore(node, refNode || null);
-      this.length++;
-      return true;
-    } else {
-      return false;
-    }
-  }
-
-  deleteRule(index: number) {
-    this.element.removeChild(this.nodes[index]);
-    this.length--;
-  }
-
-  getRule(index: number) {
-    if (index < this.length) {
-      return this.nodes[index].textContent as string;
     } else {
       return '';
     }

--- a/packages/styled-components/src/sheet/test/Tag.test.ts
+++ b/packages/styled-components/src/sheet/test/Tag.test.ts
@@ -1,5 +1,5 @@
 import { C } from 'ts-toolbelt';
-import { CSSOMTag, TextTag, VirtualTag } from '../Tag';
+import { CSSOMTag, VirtualTag } from '../Tag';
 import { Tag } from '../types';
 
 const describeTag = (TagClass: C.Class<[], Tag>) => {
@@ -35,10 +35,6 @@ describe('CSSOMTag', () => {
     expect(childNodes.length).toBe(1);
     expect(childNodes[0].nodeName).toBe('#text');
   });
-});
-
-describe('TextTag', () => {
-  describeTag(TextTag);
 });
 
 describe('VirtualTag', () => {

--- a/packages/styled-components/src/sheet/types.ts
+++ b/packages/styled-components/src/sheet/types.ts
@@ -21,7 +21,6 @@ export interface GroupedTag {
 export type SheetOptions = {
   isServer: boolean;
   target?: InsertionTarget | undefined;
-  useCSSOMInjection: boolean;
 };
 
 export interface Sheet {


### PR DESCRIPTION
This removes the need to set `process.env.SC_DISABLE_SPEEDY` to `false` in build tools to have the dev mode experience be fast