### PR TITLE
Include Emotion CSS in migration recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ If you want to become the long-term maintainer of a styled-components fork, plea
 While we'll address critical bugs and security issues, you should plan to migrate to a long-term CSS-in-JS solution like:
 
 - [vanilla-extract](https://vanilla-extract.style/) (our choice)
+- [Emotion CSS](https://emotion.sh/docs/introduction) (near-identical API)
 - [Tailwind CSS](https://tailwindcss.com/)
 - [Linaria](https://linaria.dev/)
 - [StyleX](https://stylexjs.com/)


### PR DESCRIPTION
Added recommendation for Emotion CSS as a migration option.

I won't put this above `vanilla-extract`, since that's your choice - but if someone is already invested in styled-components, it's the most natural place to go, and the least effort: the API is near-identical to styled-components, and it's noticeably faster.

We migrated a 400K LOC project in a few days, and it was worth it. 🙂
